### PR TITLE
Feature/217 enum pet gender

### DIFF
--- a/src/main/java/com/company/constants/Constants.java
+++ b/src/main/java/com/company/constants/Constants.java
@@ -17,6 +17,7 @@ public class Constants {
     // PET ERRORS
     public static final String PET_NAME_REQUIRED = "Pet name is required";
     public static final String PET_GENDER_REQUIRED = "Pet gender is required and must be valid";
+    public static final String WRONG_PET_GENDER = "Pet gender must be valid";
     public static final String PET_SIZE_REQUIRED = "Pet size is required";
     public static final String PET_OWNER_REQUIRED = "Pet owner is required and needs to be greater than 0";
     public static final String PET_BREED_REQUIRED = "Pet breed is required and needs to be greater than 0";

--- a/src/main/java/com/company/enums/PetGender.java
+++ b/src/main/java/com/company/enums/PetGender.java
@@ -16,7 +16,7 @@ public enum PetGender {
     private String id;
 
     public static boolean isValidGender(String gender) {
-        return Arrays.stream(PetStatus.values()).anyMatch(e -> e.getId().equalsIgnoreCase(gender));
+        return Arrays.stream(PetGender.values()).anyMatch(e -> e.getId().equalsIgnoreCase(gender));
     }
 
     public static PetGender getGenderById(String gender) {

--- a/src/main/java/com/company/enums/PetGender.java
+++ b/src/main/java/com/company/enums/PetGender.java
@@ -1,0 +1,6 @@
+package com.company.enums;
+
+public enum PetGender {
+    MACHO,
+    HEMBRA
+}

--- a/src/main/java/com/company/enums/PetGender.java
+++ b/src/main/java/com/company/enums/PetGender.java
@@ -1,6 +1,18 @@
 package com.company.enums;
 
+import java.util.Arrays;
+
 public enum PetGender {
-    MACHO,
-    HEMBRA
+    MACHO("MACHO"),
+    HEMBRA("HEMBRA");
+
+    PetGender(String id) {
+        this.id = id;
+    }
+
+    private String id;
+
+    public static boolean isValidGender(String gender) {
+        return Arrays.stream(PetStatus.values()).anyMatch(e -> e.getId().equalsIgnoreCase(gender));
+    }
 }

--- a/src/main/java/com/company/enums/PetGender.java
+++ b/src/main/java/com/company/enums/PetGender.java
@@ -1,7 +1,10 @@
 package com.company.enums;
 
+import lombok.Getter;
+
 import java.util.Arrays;
 
+@Getter
 public enum PetGender {
     MACHO("MACHO"),
     HEMBRA("HEMBRA");
@@ -14,5 +17,9 @@ public enum PetGender {
 
     public static boolean isValidGender(String gender) {
         return Arrays.stream(PetStatus.values()).anyMatch(e -> e.getId().equalsIgnoreCase(gender));
+    }
+
+    public static PetGender getGenderById(String gender) {
+        return Arrays.stream(PetGender.values()).filter(e -> e.getId().equalsIgnoreCase(gender)).findFirst().get();
     }
 }

--- a/src/main/java/com/company/model/dto/PetWithImagesDto.java
+++ b/src/main/java/com/company/model/dto/PetWithImagesDto.java
@@ -22,4 +22,9 @@ public class PetWithImagesDto {
     private Integer breedId;
     private Integer ownerId;
     private List<ImageWithTitle> images;
+
+    public PetWithImagesDto setImages(List<ImageWithTitle> images) {
+        this.images = images;
+        return this;
+    }
 }

--- a/src/main/java/com/company/model/entity/Pets.java
+++ b/src/main/java/com/company/model/entity/Pets.java
@@ -2,6 +2,7 @@ package com.company.model.entity;
 
 import com.company.enums.PetGender;
 import com.company.enums.PetStatus;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -42,8 +43,8 @@ public class Pets {
 
     private String size;
 
-    @Enumerated(EnumType.STRING)
-    private PetGender gender;
+    //@Enumerated(EnumType.STRING)
+    private String gender;
 
     private String description;
 
@@ -57,7 +58,7 @@ public class Pets {
     private UserDetails userDetails;
 
 
-    public Pets(String name, PetStatus status, String size, PetGender gender, String description) {
+    public Pets(String name, PetStatus status, String size, String gender, String description) {
         this.name = name;
         this.status = status;
         this.size = size;

--- a/src/main/java/com/company/model/entity/Pets.java
+++ b/src/main/java/com/company/model/entity/Pets.java
@@ -1,5 +1,6 @@
 package com.company.model.entity;
 
+import com.company.enums.PetGender;
 import com.company.enums.PetStatus;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -39,7 +40,8 @@ public class Pets {
 
     private String size;
 
-    private String gender;
+    @Enumerated(EnumType.STRING)
+    private PetGender gender;
 
     private String description;
 
@@ -53,7 +55,7 @@ public class Pets {
     private UserDetails userDetails;
 
 
-    public Pets(String name, PetStatus status, String size, String gender, String description) {
+    public Pets(String name, PetStatus status, String size, PetGender gender, String description) {
         this.name = name;
         this.status = status;
         this.size = size;

--- a/src/main/java/com/company/model/entity/Pets.java
+++ b/src/main/java/com/company/model/entity/Pets.java
@@ -1,8 +1,7 @@
 package com.company.model.entity;
 
-import com.company.enums.PetGender;
+
 import com.company.enums.PetStatus;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -43,7 +42,6 @@ public class Pets {
 
     private String size;
 
-    //@Enumerated(EnumType.STRING)
     private String gender;
 
     private String description;

--- a/src/main/java/com/company/service/PetService.java
+++ b/src/main/java/com/company/service/PetService.java
@@ -42,6 +42,7 @@ import static com.company.constants.Constants.PET_GENDER_REQUIRED;
 import static com.company.constants.Constants.PET_NAME_REQUIRED;
 import static com.company.constants.Constants.PET_OWNER_REQUIRED;
 import static com.company.constants.Constants.PET_SIZE_REQUIRED;
+import static com.company.constants.Constants.WRONG_PET_GENDER;
 import static com.company.utils.Mapper.mapCreatePetDtoToPet;
 import static com.company.utils.Mapper.mapPetToPetWithImages;
 
@@ -110,7 +111,6 @@ public class PetService implements IPetService {
     @Transactional
     public PetWithImagesDto saveOwnPetWithImages(CreatePetDto pet, MultipartFile[] images) {
         validateBasicPetData(pet, false);
-        validateGender(pet.getGender());
 
         Pets fullPet = mapCreatePetDtoToPet(pet);
 
@@ -135,7 +135,6 @@ public class PetService implements IPetService {
     @Transactional
     public PetWithImagesDto saveAdoptivePetWithImages(CreatePetDto pet, MultipartFile[] images) {
         validateBasicPetData(pet, true);
-        validateGender(pet.getGender());
 
         Pets fullPet = mapCreatePetDtoToPet(pet);
 
@@ -293,22 +292,12 @@ public class PetService implements IPetService {
         }
 
         if (pet.getGender() != null && !PetGender.isValidGender(pet.getGender())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, PET_GENDER_REQUIRED);
-        }
-        if (pet.getGender() == null || pet.getGender().isEmpty()) {
-            pet.setGender("");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, WRONG_PET_GENDER);
         }
 
         if (isForAdoption) {
-            if (pet.getGender() == null || pet.getGender().isEmpty() || !PetGender.isValidGender(pet.getGender())) {
+            if (pet.getGender() == null || pet.getGender().isEmpty()) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST, PET_GENDER_REQUIRED);
-            }
-            if (pet.getGender() != null || ! pet.getGender().isEmpty()){
-                try {
-                    PetGender.isValidGender(pet.getGender());
-                } catch (ResponseStatusException e) {
-                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, PET_GENDER_REQUIRED);
-                }
             }
 
             if (pet.getSize() == null || pet.getSize().isEmpty()) {

--- a/src/main/java/com/company/service/PetService.java
+++ b/src/main/java/com/company/service/PetService.java
@@ -1,19 +1,30 @@
 package com.company.service;
 
+import com.company.enums.PetGender;
 import com.company.model.entity.Pets;
 import com.company.enums.PetStatus;
+import com.company.model.dto.CreatePetDto;
+import com.company.model.dto.ImageWithTitle;
+import com.company.model.dto.PetWithImagesDto;
+import com.company.model.entity.Breeds;
+import com.company.model.entity.Image;
 import com.company.model.entity.Location;
 import com.company.model.entity.UserDetails;
+import com.company.repository.IBreedsRepository;
+import com.company.repository.IImageRepository;
 import com.company.repository.IPetsRepository;
 import com.company.repository.IUserDetailsRepository;
 import com.company.repository.LocationRepository;
+import com.company.service.interfaces.IPetService;
 import jakarta.persistence.criteria.Join;
+import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.ArrayList;
@@ -22,16 +33,28 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.company.constants.Constants.BREED_NOT_FOUND;
 import static com.company.constants.Constants.LOCATION_NOT_FOUND;
 import static com.company.constants.Constants.OWNER_NOT_FOUND;
+import static com.company.constants.Constants.PET_BREED_REQUIRED;
+import static com.company.constants.Constants.PET_DESCRIPTION_REQUIRED;
+import static com.company.constants.Constants.PET_GENDER_REQUIRED;
+import static com.company.constants.Constants.PET_NAME_REQUIRED;
+import static com.company.constants.Constants.PET_OWNER_REQUIRED;
+import static com.company.constants.Constants.PET_SIZE_REQUIRED;
+import static com.company.utils.Mapper.mapCreatePetDtoToPet;
+import static com.company.utils.Mapper.mapPetToPetWithImages;
 
 @AllArgsConstructor
 @Service
-public class PetService implements  IPetService{
+public class PetService implements IPetService {
 
     private IPetsRepository IPetsRepository;
     private IUserDetailsRepository userDetailsRepository;
     private final LocationRepository locationRepository;
+    private BucketImageService bucketImageService;
+    private IImageRepository imageRepository;
+    private IBreedsRepository breedsRepository;
 
     public Page<Pets> findAll(Pageable pageable) throws Exception {
         try {
@@ -81,11 +104,55 @@ public class PetService implements  IPetService{
         }
     }
 
+    @Override
+    @Transactional
+    public PetWithImagesDto saveOwnPetWithImages(CreatePetDto pet, MultipartFile[] images) {
+        validateBasicPetData(pet, false);
+
+        Pets fullPet = mapCreatePetDtoToPet(pet);
+
+        fullPet.setBreed(validateBreeds(pet.getBreedId()));
+        fullPet.setUserDetails(validateUserDetails(pet.getOwnerId()));
+        fullPet.setStatus(PetStatus.MASCOTA_PROPIA);
+
+        Pets savedPet = IPetsRepository.save(fullPet);
+
+        if (images == null || images.length == 0) {
+            return mapPetToPetWithImages(savedPet, null);
+        }
+
+        List<ImageWithTitle> savedImages = bucketImageService.uploadFileWithTitle(images);
+
+        List<ImageWithTitle> returnImages = saveImagesInDatabase(savedImages, savedPet.getId());
+
+        return mapPetToPetWithImages(savedPet, returnImages);
+    }
+
+    @Override
+    @Transactional
+    public PetWithImagesDto saveAdoptivePetWithImages(CreatePetDto pet, MultipartFile[] images) {
+        validateBasicPetData(pet, true);
+
+        Pets fullPet = mapCreatePetDtoToPet(pet);
+
+        fullPet.setBreed(validateBreeds(pet.getBreedId()));
+        fullPet.setUserDetails(validateUserDetails(pet.getOwnerId()));
+        fullPet.setStatus(PetStatus.EN_ADOPCION);
+
+        Pets savedPet = IPetsRepository.save(fullPet);
+
+        List<ImageWithTitle> savedImages = bucketImageService.uploadFileWithTitle(images);
+
+        List<ImageWithTitle> returnImages = saveImagesInDatabase(savedImages, savedPet.getId());
+
+        return mapPetToPetWithImages(savedPet, returnImages);
+    }
+
     public void deleteById(int id) throws Exception {
         Optional<Pets> species = IPetsRepository.findById(id);
         if (species.isPresent()) {
-            IPetsRepository.deleteById( id);
-        }else{
+            IPetsRepository.deleteById(id);
+        } else {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Pet not found");
         }
     }
@@ -153,12 +220,6 @@ public class PetService implements  IPetService{
         }
     }
 
-
-
-
-
-
-
     @Override
     public Page<Pets> findByStatus(PetStatus status, Pageable pageable) throws Exception {
         try {
@@ -179,6 +240,86 @@ public class PetService implements  IPetService{
         }
     }
 
+    public Page<Pets> findByLocation(int id, Pageable pageable) throws Exception {
+        validateLocation(id);
+        try {
+            return IPetsRepository.findByLocation(id, pageable);
+        } catch (Exception e) {
+            throw new Exception("Error al recuperar las mascotas paginadas.");
+        }
+    }
+
+    public Page<Pets> findByOwner(int id, Pageable pageable) throws Exception {
+        validateUserDetails(id);
+        try {
+            return IPetsRepository.findByOwner(id, pageable);
+        } catch (Exception e) {
+            throw new Exception("Error al recuperar las mascotas paginadas.");
+        }
+    }
+
+    private Breeds validateBreeds(int id) {
+        Optional<Breeds> breeds = breedsRepository.findById(id);
+        if (breeds.isPresent()) {
+            return breeds.get();
+        } else {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, BREED_NOT_FOUND);
+        }
+    }
+
+    private UserDetails validateUserDetails(int id) {
+        Optional<UserDetails> userDetails = userDetailsRepository.findById(id);
+        if (userDetails.isPresent()) {
+            return userDetails.get();
+        } else {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, OWNER_NOT_FOUND);
+        }
+    }
+
+    private void validateBasicPetData(CreatePetDto pet, boolean isForAdoption) {
+        if (pet.getName() == null || pet.getName().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, PET_NAME_REQUIRED);
+        }
+        if (pet.getOwnerId() == null || pet.getOwnerId() < 1) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, PET_OWNER_REQUIRED);
+        }
+        if (pet.getBreedId() == null || pet.getBreedId() < 1) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, PET_BREED_REQUIRED);
+        }
+
+        if (isForAdoption) {
+            if (pet.getGender() == null || pet.getGender().isEmpty() || !PetGender.isValidGender(pet.getGender())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, PET_GENDER_REQUIRED);
+            }
+            if (pet.getSize() == null || pet.getSize().isEmpty()) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, PET_SIZE_REQUIRED);
+            }
+            // TODO: Revalidate this case
+            if (pet.getDescription() == null || pet.getDescription().isEmpty()) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, PET_DESCRIPTION_REQUIRED);
+            }
+        }
+    }
+
+    private List<ImageWithTitle> saveImagesInDatabase(List<ImageWithTitle> images, int petId) {
+        List<Image> imagesToSave = images.stream().map(image -> {
+            Image newImage = new Image();
+            newImage.setUrl(image.getUrl());
+            newImage.setTitle(image.getTitle());
+            newImage.setPetID(petId);
+            return newImage;
+        }).toList();
+
+        List<Image> savedImages = imageRepository.saveAll(imagesToSave);
+
+        return savedImages.stream().map(image -> {
+            ImageWithTitle newImage = new ImageWithTitle();
+            newImage.setId(image.getId());
+            newImage.setUrl(image.getUrl());
+            newImage.setTitle(image.getTitle());
+            return newImage;
+        }).toList();
+    }
 
     private Specification<Pets> buildSpecification(String location, String species, Integer breedId, String size, String status) {
         Specification<Pets> spec = Specification.where(null);
@@ -217,41 +358,13 @@ public class PetService implements  IPetService{
         return spec;
     }
 
-    public Page<Pets> findByLocation(int id, Pageable pageable) throws Exception {
-        validateLocation(id);
-        try {
-            return IPetsRepository.findByLocation(id, pageable);
-        } catch (Exception e) {
-            throw new Exception("Error al recuperar las mascotas paginadas.");
-        }
-    }
-
-    public Page<Pets> findByOwner(int id, Pageable pageable) throws Exception {
-        validateUserDetails(id);
-        try {
-            return IPetsRepository.findByOwner(id, pageable);
-        } catch (Exception e) {
-            throw new Exception("Error al recuperar las mascotas paginadas.");
-        }
-    }
-
-    private UserDetails validateUserDetails(int id) {
-        Optional<UserDetails> userDetails = userDetailsRepository.findById(id);
-        if (userDetails.isPresent()) {
-            return userDetails.get();
-        } else {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND,OWNER_NOT_FOUND);
-        }
-    }
-
     private Location validateLocation(int id) {
         Optional<Location> location = locationRepository.findById(id);
         if (location.isPresent()) {
             return location.get();
         } else {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND,LOCATION_NOT_FOUND);
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, LOCATION_NOT_FOUND);
         }
     }
-
 
 }

--- a/src/main/java/com/company/service/PetService.java
+++ b/src/main/java/com/company/service/PetService.java
@@ -80,6 +80,7 @@ public class PetService implements IPetService {
 
     public Pets update(int id, Pets updatedPets) {
         Optional<Pets> existingPet = IPetsRepository.findById(id);
+        validateGender(updatedPets.getGender());
 
         if (existingPet.isPresent()) {
             Pets pets = existingPet.get();

--- a/src/main/java/com/company/service/PetService.java
+++ b/src/main/java/com/company/service/PetService.java
@@ -287,6 +287,8 @@ public class PetService implements IPetService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, PET_BREED_REQUIRED);
         }
 
+        // TODO: Agregar validacion en el caso de que se pase un genero en la mascota personal. No es obligatorio, por lo que solo hay que validar si llega el dato como parametro.
+
         if (isForAdoption) {
             if (pet.getGender() == null || pet.getGender().isEmpty() || !PetGender.isValidGender(pet.getGender())) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST, PET_GENDER_REQUIRED);

--- a/src/main/java/com/company/utils/Mapper.java
+++ b/src/main/java/com/company/utils/Mapper.java
@@ -1,6 +1,6 @@
 package com.company.utils;
 
-import com.company.enums.PetGender;
+
 import com.company.model.dto.CreatePetDto;
 import com.company.model.dto.ImageWithTitle;
 import com.company.model.dto.PetWithImagesDto;

--- a/src/main/java/com/company/utils/Mapper.java
+++ b/src/main/java/com/company/utils/Mapper.java
@@ -8,6 +8,7 @@ import com.company.model.entity.Pets;
 
 import java.util.List;
 
+
 public class Mapper {
     public static PetWithImagesDto mapPetToPetWithImages(Pets pet, List<ImageWithTitle> images) {
         PetWithImagesDto petWithImagesDto = new PetWithImagesDto();
@@ -15,7 +16,7 @@ public class Mapper {
         petWithImagesDto.setName(pet.getName());
         petWithImagesDto.setStatusId(pet.getStatus().getId());
         petWithImagesDto.setSize(pet.getSize());
-        petWithImagesDto.setGender(pet.getGender().getId());
+        petWithImagesDto.setGender(pet.getGender());
         petWithImagesDto.setDescription(pet.getDescription());
         petWithImagesDto.setBreedId(pet.getBreed().getId());
         petWithImagesDto.setOwnerId(pet.getUserDetails().getId());
@@ -27,8 +28,7 @@ public class Mapper {
         Pets pet = new Pets();
         pet.setName(createPetDto.getName());
         pet.setSize(String.valueOf(createPetDto.getSize()));
-        // TODO: Verificar que se guarda correctamente. Si se usa string no hace falta validarlo (ya que se deberia haber hecho en el service). En caso de usar enum, habria que ver si no rompe que este vacio.
-        pet.setGender(PetGender.getGenderById(createPetDto.getGender()));
+        pet.setGender(String.valueOf(createPetDto.getGender()));
         pet.setDescription(String.valueOf(createPetDto.getDescription()));
         return pet;
     }

--- a/src/main/java/com/company/utils/Mapper.java
+++ b/src/main/java/com/company/utils/Mapper.java
@@ -1,5 +1,6 @@
 package com.company.utils;
 
+import com.company.enums.PetGender;
 import com.company.model.dto.CreatePetDto;
 import com.company.model.dto.ImageWithTitle;
 import com.company.model.dto.PetWithImagesDto;
@@ -14,7 +15,7 @@ public class Mapper {
         petWithImagesDto.setName(pet.getName());
         petWithImagesDto.setStatusId(pet.getStatus().getId());
         petWithImagesDto.setSize(pet.getSize());
-        petWithImagesDto.setGender(pet.getGender());
+        petWithImagesDto.setGender(pet.getGender().getId());
         petWithImagesDto.setDescription(pet.getDescription());
         petWithImagesDto.setBreedId(pet.getBreed().getId());
         petWithImagesDto.setOwnerId(pet.getUserDetails().getId());
@@ -26,7 +27,7 @@ public class Mapper {
         Pets pet = new Pets();
         pet.setName(createPetDto.getName());
         pet.setSize(String.valueOf(createPetDto.getSize()));
-        pet.setGender(String.valueOf(createPetDto.getGender()));
+        pet.setGender(PetGender.getGenderById(createPetDto.getGender()));
         pet.setDescription(String.valueOf(createPetDto.getDescription()));
         return pet;
     }

--- a/src/main/java/com/company/utils/Mapper.java
+++ b/src/main/java/com/company/utils/Mapper.java
@@ -27,6 +27,7 @@ public class Mapper {
         Pets pet = new Pets();
         pet.setName(createPetDto.getName());
         pet.setSize(String.valueOf(createPetDto.getSize()));
+        // TODO: Verificar que se guarda correctamente. Si se usa string no hace falta validarlo (ya que se deberia haber hecho en el service). En caso de usar enum, habria que ver si no rompe que este vacio.
         pet.setGender(PetGender.getGenderById(createPetDto.getGender()));
         pet.setDescription(String.valueOf(createPetDto.getDescription()));
         return pet;

--- a/src/main/resources/02-data.sql
+++ b/src/main/resources/02-data.sql
@@ -578,26 +578,26 @@ VALUES
 -- ingreso de mascotas --
 INSERT INTO pets (name, owner_id, breed_id, status, size, gender, description)
 VALUES
-    (N'Buddy', 1, 21, 'MASCOTA_PROPIA', N'Mediano', 'Macho', N'Buddy es un perro cariñoso y juguetón que adora correr por el parque.'),
-    (N'Luna', 2, 32, 'MASCOTA_PROPIA', N'Pequeño', 'Hembra', N'Luna es una gatita elegante y curiosa que le encanta explorar la casa.'),
-    (N'Max', 3, 21, 'MASCOTA_PROPIA', N'Grande', 'Macho', N'Max es un perro grande y amigable que siempre está listo para pasear.'),
-    (N'Molly', 4, 21, 'EN_ADOPCION', N'Mediano', 'Hembra', N'Molly es una perrita dulce y leal que adora estar en compañía de su familia.'),
-    (N'Rocky', 5, 15, 'EN_ADOPCION', N'Pequeño', 'Macho', N'Rocky es un perro pequeño pero valiente que protege a su familia en todo momento.'),
-    (N'Bella', 6, 18, 'EN_ADOPCION', N'Grande', 'Hembra', N'Bella es una perrita grande y gentil que disfruta de largos paseos en el parque.'),
-    (N'Charlie', 7, 14, 'EN_ADOPCION', N'Mediano', 'Macho', N'Charlie es un perro amigable y enérgico que siempre está lleno de energía.'),
-    (N'Daisy', 8, 3, 'EN_ADOPCION', N'Pequeño', 'Hembra', N'Daisy es una perrita pequeña y traviesa que adora jugar con sus juguetes.'),
-    (N'Cooper', 9, 21, 'EN_ADOPCION', N'Grande', 'Macho', N'Cooper es un perro grande y protector que siempre cuida de su familia.'),
-    (N'Zoe', 10, 36, 'EN_ADOPCION', N'Mediano', 'Hembra', N'Zoe es una gatita cariñosa y juguetona que ama los mimos y caricias.'),
-    (N'Pirata', 1, 37, 'EN_ADOPCION', N'Pequeño', 'Macho', N'Pirata es un gatito curioso y aventurero que está buscando un hogar.'),
-    (N'Misty', 2, 29, 'EN_ADOPCION', N'Grande', 'Hembra', N'Misty es una perra grande y dulce que merece una familia amorosa.'),
-    (N'Leo', 3, 7, 'EN_ADOPCION', N'Mediano', 'Macho', N'Leo es un perro activo y juguetón que necesita un lugar donde correr y jugar.'),
-    (N'Lucky', 4, 1, 'ADOPTADA', N'Pequeño', 'Hembra', N'Lucky es una perrita afortunada en busca de un hogar cálido y cariñoso.'),
-    (N'Oliver', 5, 19, 'ADOPTADA', N'Grande', 'Macho', N'Oliver es un perro grande y noble que se lleva bien con todos.'),
-    (N'Sasha', 6, 18, 'ADOPTADA', N'Mediano', 'Hembra', N'Sasha es una perra mediana y cariñosa que te dará mucho amor.'),
-    (N'Teddy', 7, 31, 'ADOPTADA', N'Pequeño', 'Macho', N'Teddy es un perrito pequeño y tierno en busca de un compañero fiel.'),
-    (N'Bentley', 8, 4, 'ADOPTADA', N'Grande', 'Hembra', N'Bentley es una perra grande y leal que te protegerá siempre.'),
-    (N'Milo', 9, 21, 'ADOPTADA', N'Mediano', 'Macho', N'Milo es un perro mediano y juguetón que alegrará tu hogar.'),
-    (N'Lucio', 10, 3, 'ADOPTADA', N'Pequeño', 'Macho', N'Lucio es un perrito pequeño y encantador que te hará sonreír.');
+    (N'Buddy', 1, 21, 'MASCOTA_PROPIA', N'Mediano', 'MACHO', N'Buddy es un perro cariñoso y juguetón que adora correr por el parque.'),
+    (N'Luna', 2, 32, 'MASCOTA_PROPIA', N'Pequeño', 'HEMBRA', N'Luna es una gatita elegante y curiosa que le encanta explorar la casa.'),
+    (N'Max', 3, 21, 'MASCOTA_PROPIA', N'Grande', 'MACHO', N'Max es un perro grande y amigable que siempre está listo para pasear.'),
+    (N'Molly', 4, 21, 'EN_ADOPCION', N'Mediano', 'HEMBRA', N'Molly es una perrita dulce y leal que adora estar en compañía de su familia.'),
+    (N'Rocky', 5, 15, 'EN_ADOPCION', N'Pequeño', 'MACHO', N'Rocky es un perro pequeño pero valiente que protege a su familia en todo momento.'),
+    (N'Bella', 6, 18, 'EN_ADOPCION', N'Grande', 'HEMBRA', N'Bella es una perrita grande y gentil que disfruta de largos paseos en el parque.'),
+    (N'Charlie', 7, 14, 'EN_ADOPCION', N'Mediano', 'MACHO', N'Charlie es un perro amigable y enérgico que siempre está lleno de energía.'),
+    (N'Daisy', 8, 3, 'EN_ADOPCION', N'Pequeño', 'HEMBRA', N'Daisy es una perrita pequeña y traviesa que adora jugar con sus juguetes.'),
+    (N'Cooper', 9, 21, 'EN_ADOPCION', N'Grande', 'MACHO', N'Cooper es un perro grande y protector que siempre cuida de su familia.'),
+    (N'Zoe', 10, 36, 'EN_ADOPCION', N'Mediano', 'HEMBRA', N'Zoe es una gatita cariñosa y juguetona que ama los mimos y caricias.'),
+    (N'Pirata', 1, 37, 'EN_ADOPCION', N'Pequeño', 'MACHO', N'Pirata es un gatito curioso y aventurero que está buscando un hogar.'),
+    (N'Misty', 2, 29, 'EN_ADOPCION', N'Grande', 'HEMBRA', N'Misty es una perra grande y dulce que merece una familia amorosa.'),
+    (N'Leo', 3, 7, 'EN_ADOPCION', N'Mediano', 'MACHO', N'Leo es un perro activo y juguetón que necesita un lugar donde correr y jugar.'),
+    (N'Lucky', 4, 1, 'ADOPTADA', N'Pequeño', 'HEMBRA', N'Lucky es una perrita afortunada en busca de un hogar cálido y cariñoso.'),
+    (N'Oliver', 5, 19, 'ADOPTADA', N'Grande', 'MACHO', N'Oliver es un perro grande y noble que se lleva bien con todos.'),
+    (N'Sasha', 6, 18, 'ADOPTADA', N'Mediano', 'HEMBRA', N'Sasha es una perra mediana y cariñosa que te dará mucho amor.'),
+    (N'Teddy', 7, 31, 'ADOPTADA', N'Pequeño', 'MACHO', N'Teddy es un perrito pequeño y tierno en busca de un compañero fiel.'),
+    (N'Bentley', 8, 4, 'ADOPTADA', N'Grande', 'HEMBRA', N'Bentley es una perra grande y leal que te protegerá siempre.'),
+    (N'Milo', 9, 21, 'ADOPTADA', N'Mediano', 'MACHO', N'Milo es un perro mediano y juguetón que alegrará tu hogar.'),
+    (N'Lucio', 10, 3, 'ADOPTADA', N'Pequeño', 'MACHO', N'Lucio es un perrito pequeño y encantador que te hará sonreír.');
 
 
 -- ingreso de fotos de mascotas --

--- a/src/test/java/com/company/PetsTest/PetsTest.java
+++ b/src/test/java/com/company/PetsTest/PetsTest.java
@@ -1,13 +1,11 @@
 package com.company.PetsTest;
 
 import com.company.controller.PetController;
+import com.company.enums.PetGender;
 import com.company.enums.PetStatus;
-import com.company.model.entity.Breeds;
 import com.company.model.entity.Pets;
-import com.company.model.entity.Species;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,8 +30,8 @@ public class PetsTest {
 
     @BeforeAll
     public void setup() {
-        newPet =  new Pets("Dog", PetStatus.EN_ADOPCION, "Medium", "Male", "A friendly dog");
-        newPet2 = new Pets("Cat", PetStatus.EN_ADOPCION, "Medium", "Male", "A friendly cat");
+        newPet =  new Pets("Dog", PetStatus.EN_ADOPCION, "Medium", PetGender.MACHO, "A friendly dog");
+        newPet2 = new Pets("Cat", PetStatus.EN_ADOPCION, "Medium", PetGender.MACHO, "A friendly cat");
     }
     @AfterAll
     public void teardown() {
@@ -85,7 +83,7 @@ public class PetsTest {
         var bodyResult = ((Pets) result.getBody());
         int id = bodyResult.getId();
 
-        Pets updatedPet = new Pets("CatUpdate", PetStatus.EN_ADOPCION, "Small", "Female", "A friendly and adopted cat");
+        Pets updatedPet = new Pets("CatUpdate", PetStatus.EN_ADOPCION, "Small", PetGender.HEMBRA, "A friendly and adopted cat");
         ResponseEntity<Object> resultUpdateResponse = petController.updatePet(id, updatedPet);
         assertEquals(HttpStatus.OK, resultUpdateResponse.getStatusCode());
 

--- a/src/test/java/com/company/PetsTest/PetsTest.java
+++ b/src/test/java/com/company/PetsTest/PetsTest.java
@@ -30,8 +30,8 @@ public class PetsTest {
 
     @BeforeAll
     public void setup() {
-        newPet =  new Pets("Dog", PetStatus.EN_ADOPCION, "Medium", PetGender.MACHO, "A friendly dog");
-        newPet2 = new Pets("Cat", PetStatus.EN_ADOPCION, "Medium", PetGender.MACHO, "A friendly cat");
+        newPet =  new Pets("Dog", PetStatus.EN_ADOPCION, "Medium", "MACHO", "A friendly dog");
+        newPet2 = new Pets("Cat", PetStatus.EN_ADOPCION, "Medium", "MACHO", "A friendly cat");
     }
     @AfterAll
     public void teardown() {
@@ -83,7 +83,7 @@ public class PetsTest {
         var bodyResult = ((Pets) result.getBody());
         int id = bodyResult.getId();
 
-        Pets updatedPet = new Pets("CatUpdate", PetStatus.EN_ADOPCION, "Small", PetGender.HEMBRA, "A friendly and adopted cat");
+        Pets updatedPet = new Pets("CatUpdate", PetStatus.EN_ADOPCION, "Small", "HEMBRA", "A friendly and adopted cat");
         ResponseEntity<Object> resultUpdateResponse = petController.updatePet(id, updatedPet);
         assertEquals(HttpStatus.OK, resultUpdateResponse.getStatusCode());
 

--- a/src/test/java/integration/PetIntegrationTest.java
+++ b/src/test/java/integration/PetIntegrationTest.java
@@ -23,7 +23,6 @@ public class PetIntegrationTest {
     private MockMvc mockMvc;
 
 
-
     @Test
     public void getPetsRecommendation() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
@@ -31,13 +30,6 @@ public class PetIntegrationTest {
 
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/pets/recommendation/1?limit=3"))
 
-    @Test
-    public void getPetsByOwner() throws Exception {
-        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
-        ObjectMapper objectMapper = new ObjectMapper();
-
-        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/pets/owner/1"))
-
                 .andExpect(status().isOk())
                 .andReturn();
 
@@ -48,24 +40,40 @@ public class PetIntegrationTest {
         assertTrue(jsonNode.isArray() && jsonNode.size() > 0);
     }
 
+        @Test
+        public void getPetsByOwner () throws Exception {
+            this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+            ObjectMapper objectMapper = new ObjectMapper();
 
-    @Test
-    public void getPetsByLocation() throws Exception {
-        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
-        ObjectMapper objectMapper = new ObjectMapper();
+            MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/pets/owner/1"))
 
-        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/pets/locations/1"))
-                .andExpect(status().isOk())
-                .andReturn();
+                    .andExpect(status().isOk())
+                    .andReturn();
 
-        String jsonResponse = result.getResponse().getContentAsString();
-        JsonNode jsonNode = objectMapper.readTree(jsonResponse);
+            String jsonResponse = result.getResponse().getContentAsString();
+            JsonNode jsonNode = objectMapper.readTree(jsonResponse);
 
 
-        assertTrue(jsonNode.isArray() && jsonNode.size() > 0);
+            assertTrue(jsonNode.isArray() && jsonNode.size() > 0);
+        }
+
+
+        @Test
+        public void getPetsByLocation () throws Exception {
+            this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+            ObjectMapper objectMapper = new ObjectMapper();
+
+            MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/pets/locations/1"))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String jsonResponse = result.getResponse().getContentAsString();
+            JsonNode jsonNode = objectMapper.readTree(jsonResponse);
+
+
+            assertTrue(jsonNode.isArray() && jsonNode.size() > 0);
+        }
+
+
     }
 
-
-}
-
-}


### PR DESCRIPTION
# Pet Gender ENUM

- Added enum for pet gender with its validations
- The gender option selected by the user is stored successfully in the data base as part of the pet registry
- The pet's gender can be changed when updating the pet using the method PUT in the endpoint pets/{id}
- Pet test has been updated to work with the gender enum

[User Story 217 ](https://dev.azure.com/equipazo7/proyectoIntegrador/_workitems/edit/217)

![pets](https://github.com/proyecto-final-dh/backend/assets/11521135/d7e6281b-a1c7-45c2-b1de-ce2e11607e8a)

