### PR TITLE
[FEATURE] [233] - Add age attribute in pet creation

### DIFF
--- a/src/main/java/com/company/constants/Constants.java
+++ b/src/main/java/com/company/constants/Constants.java
@@ -21,6 +21,7 @@ public class Constants {
     public static final String PET_OWNER_REQUIRED = "Pet owner is required and needs to be greater than 0";
     public static final String PET_BREED_REQUIRED = "Pet breed is required and needs to be greater than 0";
     public static final String PET_DESCRIPTION_REQUIRED = "Pet description is required";
+    public static final String PET_AGE_MUST_BE_VALID = "Pet age must be equal or grater than 0";
 
     // NOT FOUND MESSAGES
     public static final String BREED_NOT_FOUND = "Breed not found";

--- a/src/main/java/com/company/model/dto/CreatePetDto.java
+++ b/src/main/java/com/company/model/dto/CreatePetDto.java
@@ -14,6 +14,7 @@ public class CreatePetDto {
     private String name;
     private String size;
     private String gender;
+    private Integer age;
     private String description;
     private Integer breedId;
     private Integer ownerId;

--- a/src/main/java/com/company/model/dto/PetWithImagesDto.java
+++ b/src/main/java/com/company/model/dto/PetWithImagesDto.java
@@ -18,6 +18,7 @@ public class PetWithImagesDto {
     private String statusId;
     private String size;
     private String gender;
+    private Integer age;
     private String description;
     private Integer breedId;
     private Integer ownerId;

--- a/src/main/java/com/company/model/entity/Image.java
+++ b/src/main/java/com/company/model/entity/Image.java
@@ -1,10 +1,11 @@
 package com.company.model.entity;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -24,8 +25,9 @@ public class Image {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
-    @Column(name = "pet_id")
-    private int petID;
+    @ManyToOne
+    @JoinColumn(name = "pet_id")
+    private Pets pet;
     private String url;
     private String title;
 

--- a/src/main/java/com/company/service/PetService.java
+++ b/src/main/java/com/company/service/PetService.java
@@ -123,7 +123,7 @@ public class PetService implements IPetService {
 
         List<ImageWithTitle> savedImages = bucketImageService.uploadFileWithTitle(images);
 
-        List<ImageWithTitle> returnImages = saveImagesInDatabase(savedImages, savedPet.getId());
+        List<ImageWithTitle> returnImages = saveImagesInDatabase(savedImages, savedPet);
 
         return mapPetToPetWithImages(savedPet, returnImages);
     }
@@ -143,7 +143,7 @@ public class PetService implements IPetService {
 
         List<ImageWithTitle> savedImages = bucketImageService.uploadFileWithTitle(images);
 
-        List<ImageWithTitle> returnImages = saveImagesInDatabase(savedImages, savedPet.getId());
+        List<ImageWithTitle> returnImages = saveImagesInDatabase(savedImages, savedPet);
 
         return mapPetToPetWithImages(savedPet, returnImages);
     }
@@ -304,12 +304,12 @@ public class PetService implements IPetService {
         }
     }
 
-    private List<ImageWithTitle> saveImagesInDatabase(List<ImageWithTitle> images, int petId) {
+    private List<ImageWithTitle> saveImagesInDatabase(List<ImageWithTitle> images, Pets pet) {
         List<Image> imagesToSave = images.stream().map(image -> {
             Image newImage = new Image();
             newImage.setUrl(image.getUrl());
             newImage.setTitle(image.getTitle());
-            newImage.setPetID(petId);
+            newImage.setPet(pet);
             return newImage;
         }).toList();
 

--- a/src/main/java/com/company/service/PetService.java
+++ b/src/main/java/com/company/service/PetService.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import static com.company.constants.Constants.BREED_NOT_FOUND;
 import static com.company.constants.Constants.LOCATION_NOT_FOUND;
 import static com.company.constants.Constants.OWNER_NOT_FOUND;
+import static com.company.constants.Constants.PET_AGE_MUST_BE_VALID;
 import static com.company.constants.Constants.PET_BREED_REQUIRED;
 import static com.company.constants.Constants.PET_DESCRIPTION_REQUIRED;
 import static com.company.constants.Constants.PET_GENDER_REQUIRED;
@@ -284,6 +285,9 @@ public class PetService implements IPetService {
         }
         if (pet.getBreedId() == null || pet.getBreedId() < 1) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, PET_BREED_REQUIRED);
+        }
+        if(pet.getAge() != null && pet.getAge() < 0){
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, PET_AGE_MUST_BE_VALID);
         }
 
         if (isForAdoption) {

--- a/src/main/java/com/company/utils/Mapper.java
+++ b/src/main/java/com/company/utils/Mapper.java
@@ -15,6 +15,7 @@ public class Mapper {
         petWithImagesDto.setStatusId(pet.getStatus().getId());
         petWithImagesDto.setSize(pet.getSize());
         petWithImagesDto.setGender(pet.getGender());
+        petWithImagesDto.setAge(pet.getAge());
         petWithImagesDto.setDescription(pet.getDescription());
         petWithImagesDto.setBreedId(pet.getBreed().getId());
         petWithImagesDto.setOwnerId(pet.getUserDetails().getId());
@@ -25,9 +26,10 @@ public class Mapper {
     public static Pets mapCreatePetDtoToPet(CreatePetDto createPetDto) {
         Pets pet = new Pets();
         pet.setName(createPetDto.getName());
-        pet.setSize(String.valueOf(createPetDto.getSize()));
-        pet.setGender(String.valueOf(createPetDto.getGender()));
-        pet.setDescription(String.valueOf(createPetDto.getDescription()));
+        pet.setSize(createPetDto.getSize());
+        pet.setGender(createPetDto.getGender());
+        pet.setAge(createPetDto.getAge());
+        pet.setDescription(createPetDto.getDescription());
         return pet;
     }
 }

--- a/src/test/java/com/company/imagetest/ImageTest.java
+++ b/src/test/java/com/company/imagetest/ImageTest.java
@@ -1,6 +1,7 @@
 package com.company.imagetest;
 
 import com.company.model.entity.Image;
+import com.company.model.entity.Pets;
 import com.company.repository.IImageRepository;
 import com.company.service.ImageService;
 import org.mockito.InjectMocks;
@@ -26,7 +27,7 @@ public class ImageTest {
      void testFindAll() {
         // Arrange
         Image image= new Image();
-        image.setPetID(1);
+        image.setPet(createPet());
         image.setUrl("url");
 
         // Act
@@ -43,7 +44,7 @@ public class ImageTest {
     void testSave(){
         // Arrange
         Image image= new Image();
-        image.setPetID(4);
+        image.setPet(createPet());
         image.setUrl("urlDesdeBack");
 
         // Act
@@ -52,8 +53,14 @@ public class ImageTest {
 
         // Assert
         assertNotNull(imageResponde);
-        assertEquals(imageResponde.getPetID(), image.getPetID());
+        assertEquals(imageResponde.getPet(), image.getPet());
     }
 
 
+    private Pets createPet() {
+        Pets pet = new Pets();
+        pet.setId(1);
+        pet.setName("name");
+        return pet;
+    }
 }


### PR DESCRIPTION
The objective of this PR is to add the possibility of creating a pet with the age attribute:
- For the own pet, as well as the adoptive one, the age is not a mandatory value.
- It verifies though, that if a value is given in the request body, it must be equal or greater than zero.
- It has been changed how the mapper works, so now it won't save null values as text.
- The relation between the images and the pet is changed, as it was just using the id to store it in the db. Now it has the full relation

TESTS:
Own pet:
```
{
    "name": "Bachicha",
    "breed_id": 1,
    "owner_id": 1,
    "age": 1
}
```

Adoptive pet:
```
{
    "name": "Bachicha",
    "breed_id": 1,
    "owner_id": 1,
    "gender": "MACHO",
    "size": "Pequeño",
    "description": "Descripcion porque es obligatorio",
    "age":  2
}
```