### PR TITLE
Feature/265 reports

### DIFF
--- a/src/main/java/com/company/controller/HistoryController.java
+++ b/src/main/java/com/company/controller/HistoryController.java
@@ -5,6 +5,7 @@ import com.company.model.entity.History;
 import com.company.service.HistoryService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,9 +15,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -35,8 +38,6 @@ public class HistoryController {
         History response = historyService.createHistory(item);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
-
-
 
     @GetMapping
     public List<History> getAllHistory() {
@@ -88,8 +89,42 @@ public class HistoryController {
         }
     }
 
+    //TODO: eliminar este get y llamar al servicio getAverageTimeForAdoption dentro del endpoint que está haciendo nat
+    @GetMapping("/averageTime")
+    public ResponseEntity<Object> getAvergeTimeAdoption() {
+        try {
+            return ResponseEntity.ok(historyService.getAverageTimeForAdoption());
+        } catch (ResponseStatusException ex) {
+            throw new ResponseStatusException(
+                    HttpStatus.NOT_FOUND, ex.getMessage(), ex);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("An error occurred while fetching the history");
+        }
+    }
 
+    @GetMapping("/reports/species")
+    public ResponseEntity<Object> getReportBySpecies(@RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+                                                         @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        try {
+            return ResponseEntity.ok(historyService.getReportBySpecies(startDate, endDate));
+        } catch (ResponseStatusException ex) {
+            throw new ResponseStatusException(
+                    HttpStatus.NOT_FOUND, ex.getMessage(), ex);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("An error occurred while fetching the history");
+        }
+    }
 
-
-
+    @GetMapping("/reports/status")
+    public ResponseEntity<Object> getReportByStatus(@RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+                                                         @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        try {
+            return ResponseEntity.ok(historyService.getReportByStatus(startDate, endDate));
+        } catch (ResponseStatusException ex) {
+            throw new ResponseStatusException(
+                    HttpStatus.NOT_FOUND, ex.getMessage(), ex);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("An error occurred while fetching the history");
+        }
+    }
 }

--- a/src/main/java/com/company/model/dto/AdoptionsByDateDto.java
+++ b/src/main/java/com/company/model/dto/AdoptionsByDateDto.java
@@ -1,0 +1,19 @@
+package com.company.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class AdoptionsByDateDto {
+    private String date;
+    private long count;
+}

--- a/src/main/java/com/company/model/dto/AverageTimeDto.java
+++ b/src/main/java/com/company/model/dto/AverageTimeDto.java
@@ -1,0 +1,16 @@
+package com.company.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class AverageTimeDto {
+    private String averageTime;
+}

--- a/src/main/java/com/company/model/dto/ReportBySpeciesDto.java
+++ b/src/main/java/com/company/model/dto/ReportBySpeciesDto.java
@@ -1,0 +1,20 @@
+package com.company.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ReportBySpeciesDto {
+    private int speciesId;
+    private List<AdoptionsByDateDto> result;
+
+}

--- a/src/main/java/com/company/model/dto/ReportByStatusDto.java
+++ b/src/main/java/com/company/model/dto/ReportByStatusDto.java
@@ -1,0 +1,20 @@
+package com.company.model.dto;
+
+import com.company.enums.PetStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ReportByStatusDto {
+    private PetStatus status;
+    private List<AdoptionsByDateDto> result;
+}

--- a/src/main/java/com/company/repository/IHistoryRepository.java
+++ b/src/main/java/com/company/repository/IHistoryRepository.java
@@ -2,6 +2,25 @@ package com.company.repository;
 
 import com.company.model.entity.History;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface IHistoryRepository extends JpaRepository<History, Integer> {
+    @Query(value = "CALL GetAverageTimeForAdoption()", nativeQuery = true)
+    String getAverageTimeForAdoption();
+
+    @Query(value = "CALL AdoptionsPerMonthAndSpecies(:startDate, :endDate)", nativeQuery = true)
+    List<Object[]> getAdoptionsPerMonthAndSpecies(
+            @Param("startDate") LocalDate fechaInicio,
+            @Param("endDate") LocalDate fechaFin
+    );
+
+    @Query(value = "CALL AdoptionsPerMonthAndStatus(:startDate, :endDate)", nativeQuery = true)
+    List<Object[]> getAdoptionsPerMonthAndStatus(
+            @Param("startDate") LocalDate fechaInicio,
+            @Param("endDate") LocalDate fechaFin
+    );
 }

--- a/src/main/java/com/company/service/HistoryService.java
+++ b/src/main/java/com/company/service/HistoryService.java
@@ -1,5 +1,8 @@
 package com.company.service;
 
+import com.company.model.dto.ReportBySpeciesDto;
+import com.company.model.dto.AverageTimeDto;
+import com.company.model.dto.ReportByStatusDto;
 import com.company.model.dto.SaveHistoryDto;
 import com.company.model.entity.History;
 import com.company.model.entity.Pets;
@@ -8,11 +11,13 @@ import com.company.repository.IHistoryRepository;
 import com.company.repository.IPetsRepository;
 import com.company.repository.IUserDetailsRepository;
 import com.company.service.interfaces.IHistoryService;
+import com.company.utils.Mapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -89,5 +94,24 @@ public class HistoryService implements IHistoryService {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST, "History with ID " + id + " does not exist");
         }
+    }
+
+    @Override
+    public AverageTimeDto getAverageTimeForAdoption() {
+        AverageTimeDto averageTimeDto = new AverageTimeDto();
+        averageTimeDto.setAverageTime(historyRepository.getAverageTimeForAdoption());
+        return averageTimeDto;
+    }
+
+    @Override
+    public List<ReportBySpeciesDto> getReportBySpecies(LocalDate startDate, LocalDate endDate) {
+        var response = historyRepository.getAdoptionsPerMonthAndSpecies(startDate, endDate);
+        return Mapper.mapToReportBySpeciesDtoList(response);
+    }
+
+    @Override
+    public List<ReportByStatusDto> getReportByStatus(LocalDate startDate, LocalDate endDate) {
+        var response = historyRepository.getAdoptionsPerMonthAndStatus(startDate, endDate);
+        return Mapper.mapToReportByStatusDtoList(response);
     }
 }

--- a/src/main/java/com/company/service/interfaces/IHistoryService.java
+++ b/src/main/java/com/company/service/interfaces/IHistoryService.java
@@ -1,8 +1,12 @@
 package com.company.service.interfaces;
 
+import com.company.model.dto.ReportBySpeciesDto;
+import com.company.model.dto.AverageTimeDto;
+import com.company.model.dto.ReportByStatusDto;
 import com.company.model.dto.SaveHistoryDto;
 import com.company.model.entity.History;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface IHistoryService {
@@ -17,5 +21,9 @@ public interface IHistoryService {
 
     History updateHistory(int id, History updatedHistory);
 
+    AverageTimeDto getAverageTimeForAdoption();
+
+    List<ReportBySpeciesDto> getReportBySpecies(LocalDate startDate, LocalDate endDate);
+    List<ReportByStatusDto> getReportByStatus(LocalDate startDate, LocalDate endDate);
 
 }

--- a/src/main/java/com/company/utils/Mapper.java
+++ b/src/main/java/com/company/utils/Mapper.java
@@ -1,15 +1,23 @@
 package com.company.utils;
 
 
+import com.company.enums.PetStatus;
+import com.company.model.dto.ReportBySpeciesDto;
+import com.company.model.dto.AdoptionsByDateDto;
 import com.company.model.dto.CompletePetDto;
 import com.company.model.dto.CreatePetDto;
 import com.company.model.dto.ImageWithTitle;
 import com.company.model.dto.PetWithImagesDto;
+import com.company.model.dto.ReportByStatusDto;
 import com.company.model.entity.Image;
 import com.company.model.entity.Pets;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 public class Mapper {
@@ -67,5 +75,62 @@ public class Mapper {
         completePetDto.setAge(pet.getAge());
         completePetDto.setImages(images);
         return completePetDto;
+    }
+
+    public static List<ReportBySpeciesDto> mapToReportBySpeciesDtoList (List<Object[]> responseDB){
+        Map<Integer, ReportBySpeciesDto> reportBySpeciesDtoMap = new HashMap<>();
+
+        for (Object[] row : responseDB) {
+            int speciesId = (int) row[0];
+            String dateString = row[1].toString();
+            LocalDate date = LocalDate.parse(dateString);
+            long adoptionsCount = (long) row[2];
+
+            ReportBySpeciesDto reportBySpeciesDto = reportBySpeciesDtoMap.get(speciesId);
+
+            if (reportBySpeciesDto == null) {
+                reportBySpeciesDto = new ReportBySpeciesDto();
+                reportBySpeciesDto.setSpeciesId(speciesId);
+                reportBySpeciesDto.setResult(new ArrayList<>());
+                reportBySpeciesDtoMap.put(speciesId, reportBySpeciesDto);
+            }
+
+            AdoptionsByDateDto adoptionsByDateDto = new AdoptionsByDateDto();
+            adoptionsByDateDto.setDate(date.format(DateTimeFormatter.ofPattern("MMM yyyy")));
+            adoptionsByDateDto.setCount(adoptionsCount);
+
+            reportBySpeciesDto.getResult().add(adoptionsByDateDto);
+        }
+
+        return new ArrayList<>(reportBySpeciesDtoMap.values());
+    }
+
+    public static List<ReportByStatusDto> mapToReportByStatusDtoList (List<Object[]> responseDB){
+        Map<String, ReportByStatusDto> reportByStatusDtoMap = new HashMap<>();
+
+        for (Object[] row : responseDB) {
+            String statusString = row[0].toString();
+            LocalDate date = LocalDate.parse(row[1].toString());
+            long adoptionsCount = (long) row[2];
+
+            PetStatus petStatus = PetStatus.valueOf(statusString);
+
+            ReportByStatusDto reportByStatusDto = reportByStatusDtoMap.get(statusString);
+
+            if (reportByStatusDto == null) {
+                reportByStatusDto = new ReportByStatusDto();
+                reportByStatusDto.setStatus(petStatus);
+                reportByStatusDto.setResult(new ArrayList<>());
+                reportByStatusDtoMap.put(statusString, reportByStatusDto);
+            }
+
+            AdoptionsByDateDto adoptionsByDateDto = new AdoptionsByDateDto();
+            adoptionsByDateDto.setDate(date.format(DateTimeFormatter.ofPattern("MMM yyyy")));
+            adoptionsByDateDto.setCount(adoptionsCount);
+
+            reportByStatusDto.getResult().add(adoptionsByDateDto);
+        }
+
+        return new ArrayList<>(reportByStatusDtoMap.values());
     }
 }


### PR DESCRIPTION
Agrego los siguientes reportes:
- TIEMPO PROMEDIO DESDE QUE UNA MASCOTA ES PUBLICADA PARA ADOPCIÓN HASTA QUE ES ADOPTADA
- GET DE MASCOTAS EN ADOPCIÓN DONDE PODAMOS VER EL TOTAL PUBLICADO POR ESPECIE POR MES
- GET DE MASCOTAS EN ADOPCIÓN VS ADOPTADAS, VISUALIZAR POR MES EL PORCENTAJE DE MASCOTAS PUBLICADAS VS LAS ADOPTADAS

nota: el de tiempo promedio debe devolverse dentro de la respuesta del endpoint que está trabajando nat. El metodo agregado en el controlador (getAvergeTimeAdoption) debe eliminarse y solo fue agregado para pruebas.

Los reportes fueron creador por stored procedures que son llamados desde HistoryRepository. Voy a correr a mano los sp en AWS para que puedan probar los endpoints.

requests: https://red-station-867362.postman.co/workspace/ResQPet-APIs~53c5dd78-82d2-4644-bbca-4f72255cf592/folder/16987551-688bd0d7-7d32-4e7a-9f9b-35fd27e21495?ctx=documentation

stored procedures: 
[DH - reports stored procedures.txt](https://github.com/proyecto-final-dh/backend/files/13541625/DH.-.reports.stored.procedures.txt)

