### PR TITLE
Cambio speciesId por nombre de species en reportes por especie

### DIFF
--- a/src/main/java/com/company/model/dto/ReportBySpeciesDto.java
+++ b/src/main/java/com/company/model/dto/ReportBySpeciesDto.java
@@ -14,7 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 @ToString
 public class ReportBySpeciesDto {
-    private int speciesId;
+    private String species;
     private List<AdoptionsByDateDto> result;
 
 }

--- a/src/main/java/com/company/utils/Mapper.java
+++ b/src/main/java/com/company/utils/Mapper.java
@@ -80,21 +80,21 @@ public class Mapper {
     }
 
     public static List<ReportBySpeciesDto> mapToReportBySpeciesDtoList (List<Object[]> responseDB){
-        Map<Integer, ReportBySpeciesDto> reportBySpeciesDtoMap = new HashMap<>();
+        Map<String, ReportBySpeciesDto> reportBySpeciesDtoMap = new HashMap<>();
 
         for (Object[] row : responseDB) {
-            int speciesId = (int) row[0];
+            String species = row[0].toString();
             String dateString = row[1].toString();
             LocalDate date = LocalDate.parse(dateString);
             long adoptionsCount = (long) row[2];
 
-            ReportBySpeciesDto reportBySpeciesDto = reportBySpeciesDtoMap.get(speciesId);
+            ReportBySpeciesDto reportBySpeciesDto = reportBySpeciesDtoMap.get(species);
 
             if (reportBySpeciesDto == null) {
                 reportBySpeciesDto = new ReportBySpeciesDto();
-                reportBySpeciesDto.setSpeciesId(speciesId);
+                reportBySpeciesDto.setSpecies(species);
                 reportBySpeciesDto.setResult(new ArrayList<>());
-                reportBySpeciesDtoMap.put(speciesId, reportBySpeciesDto);
+                reportBySpeciesDtoMap.put(species, reportBySpeciesDto);
             }
 
             AdoptionsByDateDto adoptionsByDateDto = new AdoptionsByDateDto();

--- a/src/main/resources/01-init.sql
+++ b/src/main/resources/01-init.sql
@@ -121,7 +121,7 @@ DELIMITER //
 CREATE PROCEDURE AdoptionsPerMonthAndSpecies(IN start_date DATE, IN end_date DATE)
 BEGIN
 
-DROP TABLE IF exists numbers;
+DROP TABLE IF EXISTS numbers;
 CREATE TEMPORARY TABLE IF NOT EXISTS numbers (
         number INT
     );
@@ -129,7 +129,7 @@ CREATE TEMPORARY TABLE IF NOT EXISTS numbers (
 INSERT INTO numbers (number) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12);
 
 SELECT
-    b.species_id AS speciesId,
+    s.name AS especie,
     m.MesInicio AS mes,
     COALESCE(COUNT(counted_data.pet_id), 0) AS cantidad_en_adopcion
 FROM (
@@ -139,6 +139,7 @@ FROM (
          WHERE DATE_ADD(start_date, INTERVAL (number - 1) MONTH) <= end_date
      ) m
          CROSS JOIN breeds b
+         LEFT JOIN species s ON b.species_id = s.id
          LEFT JOIN (
     SELECT
         DATE_FORMAT(MIN(hs.date), '%Y-%m-%d') AS mes,
@@ -150,8 +151,8 @@ FROM (
       AND hs.status = 'en_adopcion'
     GROUP BY p.breed_id, hs.pet_id
 ) AS counted_data ON MONTH(m.MesInicio) = MONTH(counted_data.mes) AND b.id = counted_data.breed_id
-GROUP BY b.species_id, m.MesInicio
-ORDER BY b.species_id, m.MesInicio;
+GROUP BY s.name, m.MesInicio
+ORDER BY s.name, m.MesInicio;
 END //
 
 DELIMITER ;


### PR DESCRIPTION
Se hizo el cambio en el stored procedure para que devuelva nombre en lugar de id

DELIMITER //

CREATE PROCEDURE AdoptionsPerMonthAndSpecies2(IN start_date DATE, IN end_date DATE)
BEGIN

    DROP TABLE IF EXISTS numbers;
    CREATE TEMPORARY TABLE IF NOT EXISTS numbers (
        number INT
    );
    -- Insertar números del 1 al 12 en la tabla numbers
    INSERT INTO numbers (number) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12);

    SELECT
        s.name AS especie,
        m.MesInicio AS mes,
        COALESCE(COUNT(counted_data.pet_id), 0) AS cantidad_en_adopcion
    FROM (
        SELECT 
            DATE_FORMAT(DATE_ADD(start_date, INTERVAL (number - 1) MONTH), '%Y-%m-%d') AS MesInicio
        FROM numbers
        WHERE DATE_ADD(start_date, INTERVAL (number - 1) MONTH) <= end_date
    ) m
    CROSS JOIN breeds b
    LEFT JOIN species s ON b.species_id = s.id
    LEFT JOIN (
        SELECT
            DATE_FORMAT(MIN(hs.date), '%Y-%m-%d') AS mes,
            p.breed_id,
            hs.pet_id
        FROM history_states hs
        JOIN pets p ON hs.pet_id = p.id
        WHERE hs.date BETWEEN start_date AND end_date
          AND hs.status = 'en_adopcion'
        GROUP BY p.breed_id, hs.pet_id
    ) AS counted_data ON MONTH(m.MesInicio) = MONTH(counted_data.mes) AND b.id = counted_data.breed_id
    GROUP BY s.name, m.MesInicio
    ORDER BY s.name, m.MesInicio;
END //

DELIMITER ;


**YA LO CORRI EN AWS**